### PR TITLE
feat(data):validacoes de data e regras de negocio silenciosas

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -124,6 +124,7 @@ Isso acontece porque, dentro da rede do Docker Compose, `db` e o endereco do con
 | `npm install` | `backend` | Instala dependencias |
 | `npx prisma migrate dev` | `backend` | Aplica migrations no banco local |
 | `npx prisma generate` | `backend` | Gera o Prisma Client |
+| `npx prisma studio` | `backend` | Abre a visualização do prisma studio no navegador |
 | `npm run dev` | `backend` | Inicia a API em desenvolvimento |
 | `npm start` | `backend` | Inicia a API com Node |
 

--- a/backend/src/services/andamentoService.js
+++ b/backend/src/services/andamentoService.js
@@ -1,5 +1,6 @@
 const andamentoRepository = require('../repositories/andamentoRepository');
 const processoRepository = require('../repositories/processoRepository');
+const { dataMenorQue, parseDataBrasileiraOuIso } = require('../utils/dateUtils');
 
 function reportaErro(message, status = 400) {
     const error = new Error(message);
@@ -27,14 +28,10 @@ function validarCamposObrigatorios(payload) {
     }
 }
 
-/* Refatorar validação de data */
-function validarData(data) {
-    const dataConvertida = new Date(data);
-
-    if(Number.isNaN(dataConvertida.getTime())) {
-        throw reportaErro('Data do andamento inválida', 400);
+function validarDataAndamento(dataAndamento, processo) {
+    if (dataMenorQue(dataAndamento, processo.dataAbertura)) {
+        throw reportaErro('A data do andamento não pode ser anterior à data de abertura do processo', 400);
     }
-    return dataConvertida;
 }
 
 const andamentoService = {
@@ -77,8 +74,11 @@ const andamentoService = {
             throw reportaErro('Processo não encontrado', 404);
         }
 
+        const dataAndamento = parseDataBrasileiraOuIso(payload.data, 'Data do andamento');
+        validarDataAndamento(dataAndamento, processo);
+
         const andamento = await andamentoRepository.create({
-            data: validarData(payload.data),
+            data: dataAndamento,
             descricao: payload.descricao,
             processosId,
         });
@@ -101,8 +101,12 @@ const andamentoService = {
             throw reportaErro('Andamento não encontrado', 404);
         }
 
+        const processo = await processoRepository.findById(andamentoExistente.processosId);
+        const dataAndamento = parseDataBrasileiraOuIso(payload.data, 'Data do andamento');
+        validarDataAndamento(dataAndamento, processo);
+
         const andamento = await andamentoRepository.update(andamentoId, {
-            data: validarData(payload.data),
+            data: dataAndamento,
             descricao: payload.descricao,
         });
 

--- a/backend/src/services/processoService.js
+++ b/backend/src/services/processoService.js
@@ -1,5 +1,6 @@
 const { report } = require('node:process');
 const processoRepository = require('../repositories/processoRepository');
+const { parseDataBrasileiraOuIso } = require('../utils/dateUtils');
 
 /* Padroniza o UF com letras maiúsculas */
 function normalizaUf(uf) {
@@ -73,7 +74,7 @@ const processoService = {
         const processo = await processoRepository.create({
             ...payload,
             uf,
-            dataAbertura: new Date(payload.dataAbertura)
+            dataAbertura: parseDataBrasileiraOuIso(payload.dataAbertura, 'Data de abertura')
         });
         
         return {
@@ -102,7 +103,7 @@ const processoService = {
         return processoRepository.update(Number(id),{
             ...payload,
             uf,
-            dataAbertura: new Date(payload.dataAbertura),
+            dataAbertura: parseDataBrasileiraOuIso(payload.dataAbertura, 'Data de abertura'),
         });
     },
     

--- a/backend/src/utils/dateUtils.js
+++ b/backend/src/utils/dateUtils.js
@@ -1,0 +1,54 @@
+function hojeAoMeioDia() {
+    const hoje = new Date();
+    return new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate(), 12, 0, 0);
+}
+
+function criarDataLocalAoMeioDia(ano, mes, dia) {
+    return new Date(ano, mes - 1, dia, 12, 0, 0);
+}
+
+function parseDataBrasileiraOuIso(value, nomeCampo = 'Data') {
+    if (!value) {
+        const error = new Error(`${nomeCampo} inválida`);
+        error.status = 400;
+        throw error;
+    }
+
+    const dataTexto = String(value).trim();
+    let data;
+
+    const brasileira = dataTexto.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+    const iso = dataTexto.match(/^(\d{4})-(\d{2})-(\d{2})/);
+
+    if (brasileira) {
+        const [, dia, mes, ano] = brasileira;
+        data = criarDataLocalAoMeioDia(Number(ano), Number(mes), Number(dia));
+    } else if (iso) {
+        const [, ano, mes, dia] = iso;
+        data = criarDataLocalAoMeioDia(Number(ano), Number(mes), Number(dia));
+    } else {
+        data = new Date(dataTexto);
+    }
+
+    if (Number.isNaN(data.getTime())) {
+        const error = new Error(`${nomeCampo} inválida`);
+        error.status = 400;
+        throw error;
+    }
+
+    const hoje = hojeAoMeioDia();
+    return data > hoje ? hoje : data;
+}
+
+function normalizarData(value) {
+    return new Date(value.getFullYear(), value.getMonth(), value.getDate(), 12, 0, 0);
+}
+
+function dataMenorQue(data, dataComparacao) {
+    return normalizarData(data) < normalizarData(dataComparacao);
+}
+
+module.exports = {
+    parseDataBrasileiraOuIso,
+    dataMenorQue,
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.16.0",
+        "date-fns": "^4.1.0",
         "lucide-react": "^1.14.0",
         "react": "^19.2.5",
+        "react-datepicker": "^9.1.0",
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.75.0",
         "react-router-dom": "^7.14.2"
@@ -432,6 +434,59 @@
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -1420,6 +1475,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1473,6 +1537,16 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2821,6 +2895,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-9.1.0.tgz",
+      "integrity": "sha512-lOp+m5bc+ttgtB5MHEjwiVu4nlp4CvJLS/PG1OiOe5pmg9kV73pEqO8H0Geqvg2E8gjqTaL9eRhSe+ZpeKP3nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.15",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "date-fns-tz": "^3.0.0",
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "date-fns-tz": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
@@ -2982,6 +3077,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "axios": "^1.16.0",
+    "date-fns": "^4.1.0",
     "lucide-react": "^1.14.0",
     "react": "^19.2.5",
+    "react-datepicker": "^9.1.0",
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.75.0",
     "react-router-dom": "^7.14.2"

--- a/frontend/src/components/AndamentoForm.jsx
+++ b/frontend/src/components/AndamentoForm.jsx
@@ -1,33 +1,34 @@
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
+import { DateField } from './DateField';
+import { toDateObject } from '../utils/dateUtils';
 
-function toDateInput(value) {
-  if (!value) return '';
-  return String(value).slice(0, 10);
-}
-
-export function AndamentoForm({ initialData, onSubmit, onCancel, isSubmitting = false }) {
+export function AndamentoForm({ initialData, onSubmit, onCancel, isSubmitting = false, minDate }) {
   const {
     register,
     handleSubmit,
     reset,
+    control,
     formState: { errors },
   } = useForm();
 
   useEffect(() => {
     reset({
-      data: toDateInput(initialData?.data),
+      data: toDateObject(initialData?.data),
       descricao: initialData?.descricao || '',
     });
   }, [initialData, reset]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      <label className="form-field">
-        Data
-        <input type="date" {...register('data', { required: 'Informe a data do andamento' })} />
-        {errors.data && <span className="text-sm text-red-600">{errors.data.message}</span>}
-      </label>
+      <DateField
+        control={control}
+        name="data"
+        label="Data"
+        requiredMessage="Informe a data do andamento"
+        error={errors.data?.message}
+        minDate={minDate}
+      />
 
       <label className="form-field">
         Descrição

--- a/frontend/src/components/DateField.jsx
+++ b/frontend/src/components/DateField.jsx
@@ -1,0 +1,41 @@
+import DatePicker, { registerLocale } from 'react-datepicker';
+import { Controller } from 'react-hook-form';
+import { ptBR } from 'date-fns/locale/pt-BR';
+import { clampFutureDate, getTodayDate, normalizeDate } from '../utils/dateUtils';
+import 'react-datepicker/dist/react-datepicker.css';
+
+registerLocale('pt-BR', ptBR);
+
+export function DateField({ control, name, label, error, requiredMessage, minDate }) {
+  const normalizedMinDate = normalizeDate(minDate);
+
+  return (
+    <label className="form-field">
+      {label}
+      <Controller
+        name={name}
+        control={control}
+        rules={{ required: requiredMessage }}
+        render={({ field }) => (
+          <DatePicker
+            selected={field.value || null}
+            onChange={(date) => field.onChange(clampFutureDate(date))}
+            onBlur={field.onBlur}
+            dateFormat="dd/MM/yyyy"
+            locale="pt-BR"
+            minDate={normalizedMinDate || undefined}
+            maxDate={getTodayDate()}
+            placeholderText="dd/mm/aaaa"
+            className="w-full"
+            wrapperClassName="w-full"
+            todayButton="Hoje"
+            showMonthDropdown
+            showYearDropdown
+            dropdownMode="select"
+          />
+        )}
+      />
+      {error && <span className="text-sm text-red-600">{error}</span>}
+    </label>
+  );
+}

--- a/frontend/src/components/ProcessoForm.jsx
+++ b/frontend/src/components/ProcessoForm.jsx
@@ -1,25 +1,23 @@
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
+import { DateField } from './DateField';
+import { toDateObject } from '../utils/dateUtils';
 
 const UFS = ['AC', 'AL', 'AP', 'AM', 'BA', 'CE', 'DF', 'ES', 'GO', 'MA', 'MG', 'MS', 'MT', 'PA', 'PB', 'PE', 'PI', 'PR', 'RJ', 'RN', 'RO', 'RR', 'RS', 'SC', 'SE', 'SP', 'TO'];
-
-function toDateInput(value) {
-  if (!value) return '';
-  return String(value).slice(0, 10);
-}
 
 export function ProcessoForm({ initialData, onSubmit, onCancel, isSubmitting = false, fieldErrors = {} }) {
   const {
     register,
     handleSubmit,
     reset,
+    control,
     formState: { errors },
   } = useForm();
 
   useEffect(() => {
     reset({
       numeroProcesso: initialData?.numeroProcesso || '',
-      dataAbertura: toDateInput(initialData?.dataAbertura),
+      dataAbertura: toDateObject(initialData?.dataAbertura),
       descricao: initialData?.descricao || '',
       cliente: initialData?.cliente || '',
       advogado: initialData?.advogado || '',
@@ -38,11 +36,13 @@ export function ProcessoForm({ initialData, onSubmit, onCancel, isSubmitting = f
           {numeroProcessoError && <span className="text-sm text-red-600">{numeroProcessoError}</span>}
         </label>
 
-        <label className="form-field">
-          Data de Abertura
-          <input type="date" {...register('dataAbertura', { required: 'Informe a data de abertura' })} />
-          {errors.dataAbertura && <span className="text-sm text-red-600">{errors.dataAbertura.message}</span>}
-        </label>
+        <DateField
+          control={control}
+          name="dataAbertura"
+          label="Data de Abertura"
+          requiredMessage="Informe a data de abertura"
+          error={errors.dataAbertura?.message}
+        />
 
         <label className="form-field">
           Cliente

--- a/frontend/src/pages/DetalhesProcesso.jsx
+++ b/frontend/src/pages/DetalhesProcesso.jsx
@@ -257,6 +257,7 @@ export function DetalhesProcesso() {
           onSubmit={salvarAndamento}
           onCancel={() => setAndamentoModalOpen(false)}
           isSubmitting={submitting}
+          minDate={processo.dataAbertura}
         />
       </Modal>
 

--- a/frontend/src/utils/dateUtils.js
+++ b/frontend/src/utils/dateUtils.js
@@ -1,0 +1,42 @@
+export function getTodayDate() {
+  const today = new Date();
+  return new Date(today.getFullYear(), today.getMonth(), today.getDate());
+}
+
+export function toDateObject(value) {
+  if (!value) return '';
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? '' : value;
+  }
+
+  const text = String(value);
+  const brazilianDate = text.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+
+  if (brazilianDate) {
+    const [, day, month, year] = brazilianDate;
+    return new Date(Number(year), Number(month) - 1, Number(day));
+  }
+
+  const date = new Date(text);
+  return Number.isNaN(date.getTime()) ? '' : date;
+}
+
+export function clampFutureDate(value) {
+  if (!value) return '';
+
+  const date = toDateObject(value);
+  if (!date) return '';
+
+  const normalizedDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const today = getTodayDate();
+
+  return normalizedDate > today ? today : normalizedDate;
+}
+
+export function normalizeDate(value) {
+  const date = toDateObject(value);
+  if (!date) return '';
+
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -1,4 +1,10 @@
 export function formatDate(date) {
   if (!date) return '-';
-  return new Date(date).toLocaleDateString('pt-BR');
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(date));
 }


### PR DESCRIPTION
Instala:

- react-datepicker
- date-fns

Cria componente reutilizável:
- DateField.jsx

Atualiza:

- ProcessoForm.jsx e AndamentoForm.jsx pra receber DateField
- dateUtils.js pra manipular e padronizar a data 

campos de data:

- mostram placeholder dd/mm/aaaa;
- abrem calendário;
- usam locale pt-BR;
- formatam visualmente como dd/MM/yyyy;
- impedem seleção de data futura com maxDate;
- se por algum caminho entrar data futura, normalizam para hoje via clampFutureDate;
- reaproveitam um único componente, evitando duplicação e código morto.


Implementa regra no backend para o calendário bloquear datas anteriores à abertura do processo. Se a tentativa for pelo postman recebe "A data do andamento não pode ser anterior à data de abertura do processo"

No frontent, componente de data aceita minDate, formulario de andamento recebe minDate e DetalhesPedido passa processo.dateAbertura como data mínima.
O calendário do andamento bloqueia visualmente datas anteriores à abertura do processo.